### PR TITLE
replace contains with indexOf

### DIFF
--- a/jump/jump.js
+++ b/jump/jump.js
@@ -49,7 +49,7 @@ var keyHandle= function(event) {
 			jumpToSlide[0] = isNaN(jumpToSlide[0]) ? 0 : parseInt(jumpToSlide[0]) - 1;
 			jumpToSlide[1] = isNaN(jumpToSlide[1]) ? 0 : parseInt(jumpToSlide[1]) - 1;
 
-			var isFlat = (typeof Reveal.getConfig().slideNumber === "string") ? Reveal.getConfig().slideNumber.contains('c') : false;
+			var isFlat = (typeof Reveal.getConfig().slideNumber === "string") ? Reveal.getConfig().slideNumber.indexOf('c') !== -1 : false;
 			if (isFlat) {
 				jumpToSlide[1] = 0;
 


### PR DESCRIPTION
Older versions of Firefox had a function `contains()`, which does not exist any more, see here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes

Instead of `includes()`, I'm using `indexOf()`, as browser support seems to be better.