### PR TITLE
Prevent link activation by enter key

### DIFF
--- a/jump/jump.js
+++ b/jump/jump.js
@@ -59,6 +59,9 @@ var keyHandle= function(event) {
 			// jump to the specified slide
 			Reveal.slide(jumpToSlide[0], jumpToSlide[1]);
 
+			// disable event processing, say, if control is active
+			event.preventDefault();
+
 			// reset jumpToSlide variable
 			jumpToSlide = "";
 		}


### PR DESCRIPTION
Without this commit, if a link is focused when the user types a number
followed by enter, the slide first changes based on the jump plugin.
Immediately afterwards, the link is activated by the enter key to jump
elsewhere.
With this commit, the enter key is only used to jump once.

To see the problem, go there: https://oer.gitlab.io/emacs-reveal-howto/howto.html
Click on the navigation control in the lower right, find yourself on slide 2. Type 3+Enter.
Find yourself on slide 7, as the control was activated by Enter on slide 3.
(If you click elsewhere first, the jump plugin works as expected.)